### PR TITLE
feat: Add records.pbx.tf for PBX IP address

### DIFF
--- a/configs/domain/records.pbx.tf
+++ b/configs/domain/records.pbx.tf
@@ -5,6 +5,6 @@ resource "aws_route53_record" "pbx" {
   zone_id = aws_route53_zone.bts_crew_com.id
   name    = "pbx"
   type    = "A"
-  records = 138.38.11.60
+  records = ["138.38.11.60"]
   ttl     = 60
 }


### PR DESCRIPTION
Additional Terraform file containing description of "A" record for BTS PBX server, hosted on campus. Thsi record can be used for BTS phone handsets to connect to the PBX without having to update IP addresses manually on each one.