### PR TITLE
feat: create records.pbx.tf for BTS PBX record

### DIFF
--- a/configs/domain/records.pbx.tf
+++ b/configs/domain/records.pbx.tf
@@ -5,6 +5,6 @@ resource "aws_route53_record" "pbx" {
   zone_id = aws_route53_zone.bts_crew_com.id
   name    = "pbx"
   type    = "A"
-  records = [138.38.11.60]
+  records = ["138.38.11.60"]
   ttl     = 60
 }


### PR DESCRIPTION
The BTS PBX server is an Asterisk VM hosted on campus. This VM has an IP address, but it is best for VoIP telephone handsets connected to it to do so using a hostname, in case any IP address changes are required in future. This PR creates a _pbx_ A record on _bts-crew.com_.