### PR TITLE
feat: create records.pc-deployment.tf

### DIFF
--- a/configs/domain/records.pc-deployment.tf
+++ b/configs/domain/records.pc-deployment.tf
@@ -1,7 +1,7 @@
 ########################################################################################################################
 # pc-deployment.bts-crew.com
 ########################################################################################################################
-resource "aws_route53_record" "bts-pxesrv" {
+resource "aws_route53_record" "bts_pxesrv" {
   zone_id = aws_route53_zone.bts_crew_com.id
   name    = "pc-deployment"
   type    = "CNAME"


### PR DESCRIPTION
<!-- PLEASE COMPLETE THIS TO THE BEST OF YOUR ABILITY -->

<!-- NOTE: your PR title will need to conform to the conventional commit spec -->

### Description

To facilitate the configuration and backing-up of our PCs, Backstage has for the last couple of years had a _PXE deployment server_ running as a VM on the SU Server in a DDaT server room. This allows our PCs (touring thin clients, Office desktops etc.) to be _netbooted_ and download a preconfigured OS image onto their hard drive over the network.

The main advantage of this is that a single installation of Windows can be configured on a single PC, complete with all Backstagey programs (Chamsys, NDI, ETC, etc.) as the _golden image_. This PC can then be PXE network-booted through one of BTS's routers (which link back to the deployment server over VPN tunnels) and the preconfigured windows image _captured_ off it. Once this image has been captured, it is stored on the deployment server, and can then be deployed to other machines over PXE.

The deployment server runs _FOG_, which has a web interface for managing computer registrations and stored OS images. This pull request therefore adds a new subdomain, _pc-deployment.bts-crew.com_, pointed at this web interface by means of the SU Server's built-in reverse proxy.

### Checklist

> [!IMPORTANT]
> Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
>
> If you're unsure about any of them, don't hesitate to ask - this is simply a reminder of what the reviewer will look
> for.

- [X] Any relevant documentation has been written/updated
- [X] Code is DRY, SOLID and clean
- [X] Code follows language code style, and style of the existing code
- [X] Code uses consistent vocabulary
- [X] Any tech debt is justified (by a comment in the code) and ticketed where appropriate
