### PR TITLE
feat: create records.telephony.tf

### DIFF
--- a/configs/domain/records.telephony.tf
+++ b/configs/domain/records.telephony.tf
@@ -1,0 +1,10 @@
+########################################################################################################################
+# telephony.bts-crew.com
+########################################################################################################################
+resource "aws_route53_record" "telephony" {
+  zone_id = aws_route53_zone.bts_crew_com.id
+  name    = "telephony"
+  type    = "CNAME"
+  records = ["bts-telephony.su.bath.ac.uk"]
+  ttl     = 60
+}


### PR DESCRIPTION
Add Terraform subdomain config for accessing web UI of BTS telephone system.

Another DNS record!

Now that the Backstage phone system, newly re-built around the more user-friendly _FreePBX_ platform, is running nicely, it would be good to have a standardised way of accessing the system's web UI, used for registering new handsets and adjusting voicemail greetings / call routing logic etc.

This PR adds a _telephony.bts-crew.com_ subdomain, used to access the PBX server's web interface via the SU Server's reverse proxy. Note that currently the subdomain will likely show a TLS error, because the Traefik reverse proxy isn't able to generate SSL certificates until the subdomain DNS record becomes public. As with the other subdomains, this error should vanish once the subdomain becomes active.

There's no need to write an essay - we welcome bullet points over prose.

Ticket: https://github.com/backstage-technical-services/hub/issues/XXX <!-- delete this if there's no issue -->

### Checklist

> [!IMPORTANT]
> Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
>
> If you're unsure about any of them, don't hesitate to ask - this is simply a reminder of what the reviewer will look
> for.

- [X] Any relevant documentation has been written/updated
- [X] Code is DRY, SOLID and clean
- [X] Code follows language code style, and style of the existing code
- [X] Code uses consistent vocabulary
- [X] Any tech debt is justified (by a comment in the code) and ticketed where appropriate
