### PR TITLE
feat(databases): increase postgres memory limits

### DIFF
--- a/configs/databases/database/_db/main.tf
+++ b/configs/databases/database/_db/main.tf
@@ -80,15 +80,11 @@ resource "kubernetes_stateful_set_v1" "default" {
           }
 
           dynamic "resources" {
-            for_each = var.memory_limit != null ? [1] : []
+            for_each = var.resources != null ? [1] : []
 
             content {
-              requests = {
-                memory = var.memory_limit
-              }
-              limits = {
-                memory = var.memory_limit
-              }
+              requests = var.resources.requests
+              limits   = var.resources.limits
             }
           }
         }

--- a/configs/databases/database/_db/variables.tf
+++ b/configs/databases/database/_db/variables.tf
@@ -32,7 +32,16 @@ variable "env" {
   type    = map(string)
   default = {}
 }
-variable "memory_limit" {
-  type    = string
+variable "resources" {
+  type = object({
+    requests = optional(object({
+      cpu    = optional(string)
+      memory = optional(string)
+    }))
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string)
+    }))
+  })
   default = null
 }

--- a/configs/databases/database/mariadb/main.tf
+++ b/configs/databases/database/mariadb/main.tf
@@ -4,8 +4,17 @@ variable "engine_version" {
 variable "default_annotations" {
   type = map(string)
 }
-variable "memory_limit" {
-  type    = string
+variable "resources" {
+  type = object({
+    requests = optional(object({
+      cpu    = optional(string)
+      memory = optional(string)
+    }))
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string)
+    }))
+  })
   default = null
 }
 
@@ -26,7 +35,7 @@ module "this" {
     MARIADB_ROOT_HOST = "localhost"
   }
 
-  memory_limit = var.memory_limit
+  resources = var.resources
 }
 
 resource "random_password" "root_password" {

--- a/configs/databases/database/postgres/main.tf
+++ b/configs/databases/database/postgres/main.tf
@@ -4,8 +4,17 @@ variable "engine_version" {
 variable "default_annotations" {
   type = map(string)
 }
-variable "memory_limit" {
-  type    = string
+variable "resources" {
+  type = object({
+    requests = optional(object({
+      cpu    = optional(string)
+      memory = optional(string)
+    }))
+    limits = optional(object({
+      cpu    = optional(string)
+      memory = optional(string)
+    }))
+  })
   default = null
 }
 
@@ -28,7 +37,7 @@ module "this" {
     POSTGRES_PASSWORD = random_password.root_password.result
   }
 
-  memory_limit = var.memory_limit
+  resources = var.resources
 }
 
 resource "random_pet" "root_username" {

--- a/configs/databases/main.tf
+++ b/configs/databases/main.tf
@@ -18,7 +18,11 @@ module "mariadb_10_4" {
   engine_version      = "10.4"
   default_annotations = local.default_annotations
 
-  memory_limit = "256Mi"
+  resources = {
+    limits = {
+      memory = "256Mi"
+    }
+  }
 }
 
 module "postgres_16" {
@@ -27,5 +31,12 @@ module "postgres_16" {
   engine_version      = "16"
   default_annotations = local.default_annotations
 
-  memory_limit = "128Mi"
+  resources = {
+    requests = {
+      memory = "1Gi"
+    }
+    limits = {
+      memory = "2Gi"
+    }
+  }
 }


### PR DESCRIPTION
### Description

Upgrades the postgres database memory to have a request of 1GB and limit of 2GB.

### Checklist

> [!IMPORTANT]
> Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
>
> If you're unsure about any of them, don't hesitate to ask - this is simply a reminder of what the reviewer will look
> for.

- [ ] ~Any relevant documentation has been written/updated~
- [x] Code is DRY, SOLID and clean
- [x] Code follows language code style, and style of the existing code
- [x] Code uses consistent vocabulary
- [ ] ~Any tech debt is justified (by a comment in the code) and ticketed where appropriate~
